### PR TITLE
✨ async'd bucket counts for performance reasons

### DIFF
--- a/src/components/queries/SearchAggCount.js
+++ b/src/components/queries/SearchAggCount.js
@@ -1,0 +1,11 @@
+import gql from "graphql-tag";
+
+const Query = gql`
+  query SearchAggCount($query: String!, $aggs: String!, $agg: String!) {
+    items: searchAggCount(query: $query, aggs: $aggs, agg: $agg) {
+      buckets
+    }
+  }
+`;
+
+export default Query;

--- a/src/components/queries/index.js
+++ b/src/components/queries/index.js
@@ -1,1 +1,2 @@
 export { default as Login } from "./Login";
+export { default as SearchAggCount } from "./SearchAggCount";

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as addInSQON } from "./addInSQON";
 export { default as withParams } from "./withParams";
 export { default as updateParams } from "./updateParams";
+export { default as namespaceField } from "./namespaceField";

--- a/src/utils/namespaceField.js
+++ b/src/utils/namespaceField.js
@@ -1,0 +1,1 @@
+export default ({ entity, field }) => `${entity}.${field}`;


### PR DESCRIPTION
the whole search process needs to be re-run to get accurate
agg bucket counts, for each term agg. because of this we can't
get accurate counts inline with the search process, so we'll
async each one